### PR TITLE
Fix typo inside README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ and [Python](https://github.com/cirla/tulipy).
 
 ## Features
 
- - **ANSI C with no dependecies**.
+ - **ANSI C with no dependencies**.
  - Uses fast algorithms.
  - Easy to use programming interface.
  - Release under LGPL license.


### PR DESCRIPTION
[skip ci]
- Fix typo `dependecies` to `dependencies`