### PR TITLE
Enforce C89 compliance since it's declared as a feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,7 @@ CC ?= gcc
 AR ?= ar
 RANLIB ?= ranlib
 
-#CCFLAGS ?= -Wall -Wextra -Werror -Wshadow -Wconversion -O2 -g -pg -fprofile-arcs -ftest-coverage
-#CCFLAGS ?= -Wall -Wextra -Werror -Wshadow -Wconversion -O2 -g -pedantic -std=c99
-CCFLAGS ?= -Wall -Wextra -Wshadow -Wconversion -O2 -g
+CCFLAGS ?= -Wall -Wextra -Wshadow -Wconversion -std=c89 -pedantic -Wno-declaration-after-statement -O2
 
 SRCS=$(wildcard indicators/*.c)
 SRCS+=$(wildcard utils/*.c)

--- a/indicators/msw.c
+++ b/indicators/msw.c
@@ -63,7 +63,7 @@ int ti_msw(int size, TI_REAL const *const *inputs, TI_REAL const *options, TI_RE
         phase += pi/2.0;
         if (phase < 0.0) phase += tpi;
         if (phase > tpi) phase -= tpi;
-        //phase = 180 * phase / pi;
+        /* phase = 180 * phase / pi; */
 
         *sine++ = sin(phase);
         *lead++ = sin(phase + pi/4.0);

--- a/indicators/wad.c
+++ b/indicators/wad.c
@@ -54,7 +54,7 @@ int ti_wad(int size, TI_REAL const *const *inputs, TI_REAL const *options, TI_RE
         } else if (c < yc) {
             sum += c - MAX(yc, high[i]);
         } else {
-            //No change
+            /* No change */
         }
 
         *output++ = sum;

--- a/smoke.c
+++ b/smoke.c
@@ -71,7 +71,6 @@ int get_array(FILE *fp, TI_REAL *s) {
         return 0;
     }
 
-//#pragma warning(disable:4996) //MSVC
     char *num = strtok(line+1, ",}\r\n");
 
     if (!num) {


### PR DESCRIPTION
Make it compile with `-std=c89` to ensure compliance. Introduce minor changes accordingly. Declarations after statements are permitted.