### PR TITLE
Generate more boilerplate for indicator implementations

### DIFF
--- a/indicators.tcl
+++ b/indicators.tcl
@@ -1,6 +1,6 @@
 # Tulip Indicators
 # https://tulipindicators.org/
-# Copyright (c) 2010-2018 Tulip Charts LLC
+# Copyright (c) 2010-2019 Tulip Charts LLC
 # Lewis Van Winkle (LV@tulipcharts.org)
 #
 # This file is part of Tulip Indicators.
@@ -22,7 +22,7 @@
 set license "/*
  * Tulip Indicators
  * https://tulipindicators.org/
- * Copyright (c) 2010-2018 Tulip Charts LLC
+ * Copyright (c) 2010-2019 Tulip Charts LLC
  * Lewis Van Winkle (LV@tulipcharts.org)
  *
  * This file is part of Tulip Indicators.
@@ -249,10 +249,7 @@ long int ti_build();
 "
 
       set fun_args_start {TI_REAL const *options}
-      set fun_args "int size,
-      TI_REAL const *const *inputs,
-      TI_REAL const *options,
-      TI_REAL *const *outputs"
+      set fun_args "int size, TI_REAL const *const *inputs, TI_REAL const *options, TI_REAL *const *outputs"
 
       puts $h "
 
@@ -343,14 +340,26 @@ foreach func $indicators {
         set o [open $imp w]
         puts $o $license
         puts $o {#include "../indicators.h"}
-        puts $o "\n\n"
+        puts $o "\n"
 
         puts $o "$start {"
         puts $o ""
         puts $o "}\n\n"
 
         puts $o "$fun {"
-        puts $o ""
+        set indent "    "
+        for {set i 0} {$i < $in} {incr i} {
+            puts $o "${indent}TI_REAL const *[lindex $in_names $i] = inputs\[$i\];"
+        }
+        for {set i 0} {$i < $opt} {incr i} {
+            puts $o "${indent}const TI_REAL [lindex $opt_names $i] = options\[$i\];"
+        }
+        for {set i 0} {$i < $out} {incr i} {
+            puts $o "${indent}TI_REAL *[lindex $out_names $i] = outputs\[$i\];"
+        }
+
+        puts $o "\n${indent}#error \"CODE GOES HERE\"\n"
+        puts $o "${indent}return TI_OKAY;"
         puts $o "}"
 
         close $o


### PR DESCRIPTION
Currently, `indicators.tcl` will create a template for any newly introduced indicator `ind` for which `indicators/ind.c` doesn't exists, yet it doesn't use available info in full and makes us write some things by hand.

This patch automatically generates code for input and output variables. Sample generated code for `lappend indicators [list overlay "Example" example 1 1 1 {real} {period} {example}]`:

```
/*
 * Tulip Indicators
 * https://tulipindicators.org/
 * Copyright (c) 2010-2019 Tulip Charts LLC
 * Lewis Van Winkle (LV@tulipcharts.org)
 *
 * This file is part of Tulip Indicators.
 *
 * Tulip Indicators is free software: you can redistribute it and/or modify it
 * under the terms of the GNU Lesser General Public License as published by the
 * Free Software Foundation, either version 3 of the License, or (at your
 * option) any later version.
 *
 * Tulip Indicators is distributed in the hope that it will be useful, but
 * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
 * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License
 * for more details.
 *
 * You should have received a copy of the GNU Lesser General Public License
 * along with Tulip Indicators.  If not, see <http://www.gnu.org/licenses/>.
 *
 */

#include "../indicators.h"


int ti_example_start(TI_REAL const *options) {

}


int ti_example(int size, TI_REAL const *const *inputs, TI_REAL const *options, TI_REAL *const *outputs) {
    TI_REAL const *real = inputs[0];
    const TI_REAL period = options[0];
    TI_REAL *example = outputs[0];

    #error "CODE GOES HERE"

    return TI_OKAY;
}
```