### PR TITLE
Added indicator streams and reference indicators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC ?= gcc
 AR ?= ar
 RANLIB ?= ranlib
 
-CCFLAGS ?= -Wall -Wextra -Wshadow -Wconversion -std=c89 -pedantic -Wno-declaration-after-statement -O2
+CCFLAGS ?= -Wall -Wextra -Wshadow -Wconversion -std=c99 -pedantic -O2 -g
 
 SRCS=$(wildcard indicators/*.c)
 SRCS+=$(wildcard utils/*.c)

--- a/indicators.tcl
+++ b/indicators.tcl
@@ -250,7 +250,7 @@ long int ti_build();
 
       set fun_args_start {TI_REAL const *options}
       set fun_args "int size, TI_REAL const *const *inputs, TI_REAL const *options, TI_REAL *const *outputs"
-      set fun_stream_new_args {TI_REAL const *options}
+      set fun_stream_new_args {TI_REAL const *options, ti_stream **stream}
       set fun_stream_run_args "ti_stream *stream, int size, TI_REAL const *const *inputs, TI_REAL *const *outputs"
       set fun_stream_free_args "ti_stream *stream"
 
@@ -278,7 +278,7 @@ typedef int (*ti_indicator_function)($fun_args);
 
 
 struct ti_stream; typedef struct ti_stream ti_stream;
-typedef ti_stream *(*ti_indicator_stream_new)($fun_stream_new_args);
+typedef int (*ti_indicator_stream_new)($fun_stream_new_args);
 typedef int (*ti_indicator_stream_run)($fun_stream_run_args);
 typedef void (*ti_indicator_stream_free)($fun_stream_free_args);
 
@@ -420,7 +420,7 @@ foreach func $indicators {
             append prototype "int ti_[set n]_ref($fun_args);\n"
         }
         if {[lsearch $extra stream] != -1} {
-            append prototype "ti_stream *ti_[set n]_stream_new($fun_stream_new_args);\n"
+            append prototype "int ti_[set n]_stream_new($fun_stream_new_args);\n"
             append prototype "int ti_[set n]_stream_run($fun_stream_run_args);\n"
             append prototype "void ti_[set n]_stream_free($fun_stream_free_args);\n"
         }

--- a/indicators/atr.c
+++ b/indicators/atr.c
@@ -115,22 +115,21 @@ struct ti_stream {
 };
 
 
-ti_stream *ti_atr_stream_new(TI_REAL const *options) {
+int ti_atr_stream_new(TI_REAL const *options, ti_stream **stream) {
     const int period = (int)options[0];
-    if (period < 1) return 0;
+    if (period < 1) return TI_INVALID_OPTION;
 
-    ti_stream *stream = malloc(sizeof(ti_stream));
-    if (stream) {
-
-        stream->index = TI_INDICATOR_ATR_INDEX;
-        stream->progress = -ti_atr_start(options);
-
-        stream->period = period;
-
-        stream->sum = 0.0;
-
+    *stream = malloc(sizeof(ti_stream));
+    if (!*stream) {
+        return TI_OUT_OF_MEMORY;
     }
-    return stream;
+
+    (*stream)->index = TI_INDICATOR_ATR_INDEX;
+    (*stream)->progress = -ti_atr_start(options);
+    (*stream)->period = period;
+    (*stream)->sum = 0.0;
+
+    return TI_OKAY;
 }
 
 

--- a/indicators/atr.c
+++ b/indicators/atr.c
@@ -23,6 +23,7 @@
 
 #include "../indicators.h"
 #include "truerange.h"
+#include "../utils/minmax.h"
 
 
 
@@ -68,4 +69,122 @@ int ti_atr(int size, TI_REAL const *const *inputs, TI_REAL const *options, TI_RE
 
     assert(output - outputs[0] == size - ti_atr_start(options));
     return TI_OKAY;
+}
+
+
+int ti_atr_ref(int size, TI_REAL const *const *inputs, TI_REAL const *options, TI_REAL *const *outputs) {
+
+    //atr = ti_wilders(ti_tr)
+
+    //First calculate true range.
+    const int tr_start = ti_tr_start(0);
+    const int tr_size = size - tr_start;
+    TI_REAL *truerange = malloc((unsigned int)tr_size * sizeof(TI_REAL));
+    if (!truerange) {return TI_OUT_OF_MEMORY;}
+
+    TI_REAL *tr_outputs[1] = {truerange};
+    const int tr_ret = ti_tr(size, inputs, 0, tr_outputs);
+    if (tr_ret != TI_OKAY) {
+        free(truerange);
+        return tr_ret;
+    }
+
+
+    //Then wilders.
+    const TI_REAL *wilders_inputs[1] = {truerange};
+    const int wilders_ret = ti_wilders(tr_size, wilders_inputs, options, outputs);
+
+    free(truerange);
+
+
+    assert(size - ti_atr_start(options) == size - ti_wilders_start(options));
+
+    return wilders_ret;
+}
+
+
+struct ti_stream {
+    /* required */
+    int index;
+    int progress;
+
+    /* indicator specific */
+    int period;
+    TI_REAL sum;
+    TI_REAL last;
+};
+
+
+ti_stream *ti_atr_stream_new(TI_REAL const *options) {
+    const int period = (int)options[0];
+    if (period < 1) return 0;
+
+    ti_stream *stream = malloc(sizeof(ti_stream));
+    if (stream) {
+
+        stream->index = TI_INDICATOR_ATR_INDEX;
+        stream->progress = -ti_atr_start(options);
+
+        stream->period = period;
+
+        stream->sum = 0.0;
+
+    }
+    return stream;
+}
+
+
+int ti_atr_stream_run(ti_stream *stream, int size, TI_REAL const *const *inputs, TI_REAL *const *outputs) {
+    const TI_REAL *high = inputs[0];
+    const TI_REAL *low = inputs[1];
+    const TI_REAL *close = inputs[2];
+
+    TI_REAL *output = outputs[0];
+
+    const TI_REAL per = 1.0 / ((TI_REAL)stream->period);
+
+    const int start = -(stream->period-1);
+    int i = 0; /* place in input */
+
+
+    if (stream->progress < 1) {
+        if (stream->progress == start) {
+            /* first bar of input */
+            stream->sum = high[0] - low[0];
+            ++stream->progress; ++i;
+        }
+
+        /* still calculating first output */
+        while (stream->progress <= 0 && i < size) {
+            TI_REAL truerange; CALC_TRUERANGE();
+            stream->sum += truerange;
+            ++stream->progress; ++i;
+        }
+
+        if (stream->progress == 1) {
+            const TI_REAL val = stream->sum * per;
+            stream->last = val;
+            *output++ = val;
+        }
+    }
+
+    if (stream->progress >= 1) {
+        /* steady state */
+        TI_REAL val = stream->last;
+        while (i < size) {
+            TI_REAL truerange; CALC_TRUERANGE();
+            val = (truerange-val) * per + val;
+            *output++ = val;
+            ++stream->progress; ++i;
+        }
+
+        stream->last = val;
+    }
+
+    return TI_OKAY;
+}
+
+
+void ti_atr_stream_free(ti_stream *stream) {
+    free(stream);
 }

--- a/smoke.c
+++ b/smoke.c
@@ -214,8 +214,9 @@ void run_one(FILE *fp, const char* target_name, int is_regression_test) {
         printf("running \t%s%-*s... ", info->name, 16-strlen(info->name), "_stream");
         const clock_t ts_start = clock();
 
-        ti_stream *stream = info->stream_new(options);
-        if (!stream) {
+        ti_stream *stream = 0;
+        int new_ret = info->stream_new(options, &stream);
+        if (new_ret != TI_OKAY || !stream) {
             printf("stream_new failure.\n");
             failed_cnt += 1;
             any_failures_here = 1;


### PR DESCRIPTION
Indicator streams https://github.com/TulipCharts/tulipindicators/issues/57
Reference indicators https://github.com/TulipCharts/tulipindicators/issues/59

`indicators.tcl` now takes an extra parametr for each indicator. This option can be "ref" or "stream" or both. It'll generate code accordingly.

I used ATR as the first example. ATR is easy to make a reference for (call `ti_tr`, call `ti_wilders`) and it's easy (but not trivial) to make a streaming indicator for.

I updated `smoke` to check ref and stream if available.

I updated the Makefile to c99. It's a lot easier.
