### PR TITLE
Bump the C version from 89 to 99 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ High quality bindings are available for [Node.js](https://github.com/TulipCharts
 
 ## Features
 
- - **ANSI C with no dependencies**.
+ - **C99 with no dependencies**.
  - Uses fast algorithms.
  - Easy to use programming interface.
  - Release under LGPL license.


### PR DESCRIPTION
Since bdc09f9009ff35858d8621d49f813e7d09f3f3ee, we do explicitly compile with C99. Therefore, I think, current README is misleading since e.g. MSVC is a C++ compiler and it doesn't nearly support C99 in full (as C++ as based on C89). I think, we should stick to one particular version of the standard.