### PR TITLE
Add ti_indicator_count function to the API

### DIFF
--- a/indicators.tcl
+++ b/indicators.tcl
@@ -244,6 +244,7 @@ extern \"C\" {
 
 const char* ti_version();
 long int ti_build();
+int ti_indicator_count();
 
 
 "
@@ -467,6 +468,7 @@ puts $idx "#include \"indicators.h\"\n\n"
 puts $idx "
 const char* ti_version() {return TI_VERSION;}
 long int ti_build() {return TI_BUILD;}
+int ti_indicator_count() {return TI_INDICATOR_COUNT;}
 "
 
 puts $idx "\n\n\nstruct ti_indicator_info ti_indicators\[\] = {"


### PR DESCRIPTION
This is a natural step towards cross-language bindings development simplification.