### PR TITLE
Improve compatibility with C++

### DIFF
--- a/indicators.h
+++ b/indicators.h
@@ -85,14 +85,14 @@ typedef int (*ti_indicator_function)(int size,
       TI_REAL *const *outputs);
 
 typedef struct ti_indicator_info {
-    char *name;
-    char *full_name;
+    const char *name;
+    const char *full_name;
     ti_indicator_start_function start;
     ti_indicator_function indicator;
     int type, inputs, options, outputs;
-    char *input_names[TI_MAXINDPARAMS];
-    char *option_names[TI_MAXINDPARAMS];
-    char *output_names[TI_MAXINDPARAMS];
+    const char *input_names[TI_MAXINDPARAMS];
+    const char *option_names[TI_MAXINDPARAMS];
+    const char *output_names[TI_MAXINDPARAMS];
 } ti_indicator_info;
 
 

--- a/indicators.tcl
+++ b/indicators.tcl
@@ -276,14 +276,14 @@ typedef int (*ti_indicator_start_function)($fun_args_start);
 typedef int (*ti_indicator_function)($fun_args);
 
 typedef struct ti_indicator_info {
-    char *name;
-    char *full_name;
+    const char *name;
+    const char *full_name;
     ti_indicator_start_function start;
     ti_indicator_function indicator;
     int type, inputs, options, outputs;
-    char *input_names\[TI_MAXINDPARAMS\];
-    char *option_names\[TI_MAXINDPARAMS\];
-    char *output_names\[TI_MAXINDPARAMS\];
+    const char *input_names\[TI_MAXINDPARAMS\];
+    const char *option_names\[TI_MAXINDPARAMS\];
+    const char *output_names\[TI_MAXINDPARAMS\];
 } ti_indicator_info;
 
 


### PR DESCRIPTION
Using the "amalgamate" inside a c++ project triggers the following
warning for every `ti_indicator_info` declared in the file:

```
 warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
```

Declaring the string as `const char*` instead of `char*` fixes the
warnings.