### PR TITLE
Improve compatibility with C++

### DIFF
--- a/indicators.tcl
+++ b/indicators.tcl
@@ -289,15 +289,15 @@ typedef void (*ti_indicator_stream_free)($fun_stream_free_args);
 
 
 typedef struct ti_indicator_info {
-    char *name;
-    char *full_name;
+    const char *name;
+    const char *full_name;
     ti_indicator_start_function start;
     ti_indicator_function indicator;
     ti_indicator_function indicator_ref;
     int type, inputs, options, outputs;
-    char *input_names\[TI_MAXINDPARAMS\];
-    char *option_names\[TI_MAXINDPARAMS\];
-    char *output_names\[TI_MAXINDPARAMS\];
+    const char *input_names\[TI_MAXINDPARAMS\];
+    const char *option_names\[TI_MAXINDPARAMS\];
+    const char *output_names\[TI_MAXINDPARAMS\];
     ti_indicator_stream_new stream_new;
     ti_indicator_stream_run stream_run;
     ti_indicator_stream_free stream_free;


### PR DESCRIPTION
Using the "amalgamate" inside a c++ project triggers the following
warning for every `ti_indicator_info` declared in the file:

```
 warning: conversion from string literal to 'char *' is deprecated [-Wc++11-compat-deprecated-writable-strings]
```

Declaring the string as `const char*` instead of `char*` fixes the
warnings.