### PR TITLE
ci: test build on amd64/ arm64 cpu architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: c
 before_install:
   - sudo apt-get install -y tcl
 
+arch:
+  - amd64
+  - arm64
+
 os:
   - linux
   #- osx TODO figure out how to get tcl on osx


### PR DESCRIPTION
The hourly cost of ARM64 instances on AWS is significantly lower than AMD64 instances. Ensuring build on ARM64 architectures can help projects to reduce hosting cost. 