### PR TITLE
fix(Makefile): respect CC environment variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 AR ?= ar
 RANLIB ?= ranlib
 


### PR DESCRIPTION
Makefile should respect the choice of compiler in accordance to the CC environment variable.

Fix `clang` is not being used to run build on Travis.

https://app.travis-ci.com/github/TulipCharts/tulipindicators/jobs/558733601#L202